### PR TITLE
MAL support added

### DIFF
--- a/app/src/main/java/com/fenchtose/movieratings/NetflixReaderService.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/NetflixReaderService.kt
@@ -437,6 +437,7 @@ class NetflixReaderService : AccessibilityService() {
                     title = text,
                     appName = appName,
                     order = if (preferences?.isSettingEnabled(UserPreferences.SHOW_RECENT_RATING) == true) ORDER_RECENT else ORDER_POPULAR,
+                    checkAnime = if (preferences?.isAppEnabled(UserPreferences.CHECK_ANIME) == true) 1 else 0,
                     year = if (preferences?.isAppEnabled(UserPreferences.USE_YEAR) == true) year else null
             )
 

--- a/app/src/main/java/com/fenchtose/movieratings/display/RatingDisplayer.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/display/RatingDisplayer.kt
@@ -167,13 +167,26 @@ class RatingDisplayer(ctx: Context,
                     trackEvent(GaEvents.DISMISS_RATING)
                     removeViewImmediate(it)
                 } else {
-                    val openInApp = preferences.isAppEnabled(UserPreferences.OPEN_MOVIE_IN_APP)
-                    trackEvent(GaEvents.RATING_OPEN_MOVIE.withLabel(if (openInApp) "app" else "imdb"))
-                    val opened = IntentUtils.openMovie(context, floatingRating?.rating?.imdbId, openInApp)
-                    if (opened) {
-                        removeView()
-                    }
+                    openBubble()
                 }
+            }
+        }
+
+        private fun openBubble() {
+            val openInApp = preferences.isAppEnabled(UserPreferences.OPEN_MOVIE_IN_APP)
+            val label = when(floatingRating?.rating?.source) {
+                "MAL" -> "mal"
+                "IMDB" -> if (openInApp) "app" else "imdb"
+                else -> null
+            }
+
+            label?.let {
+                trackEvent(GaEvents.RATING_OPEN_MOVIE.withLabel(it))
+            }
+
+            val opened = IntentUtils.openMovie(context, floatingRating?.rating, openInApp)
+            if (opened) {
+                removeView()
             }
         }
 

--- a/app/src/main/java/com/fenchtose/movieratings/features/settings/MiscSectionFragment.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/features/settings/MiscSectionFragment.kt
@@ -35,6 +35,7 @@ class MiscSectionFragment: BaseFragment() {
         addAppToggle(preferences, view, R.id.support_inapp_toggle, UserPreferences.SHOW_SUPPORT_APP_PROMPT)
         addAppToggle(preferences, view, R.id.api_fallback_toggle, UserPreferences.USE_FLUTTER_API)
         addSettingToggle(preferences, view, R.id.api_order_toggle, UserPreferences.SHOW_RECENT_RATING)
+        addAppToggle(preferences, view, R.id.anime_toggle, UserPreferences.CHECK_ANIME)
 
         val publisher = PublishSubject.create<String>()
         subscribe(publisher

--- a/app/src/main/java/com/fenchtose/movieratings/features/settings/bubble/BubbleService.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/features/settings/bubble/BubbleService.kt
@@ -24,7 +24,7 @@ class BubbleService: Service() {
     override fun onBind(intent: Intent?) = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val rating = MovieRating("test", 8.2f, 0, "", "", "", -1, -1)
+        val rating = MovieRating("test", 8.2f, 0, "", "", "", "", -1, -1)
         displayer?.showRatingWindow(rating)
 
         disposable = EventBus.subscribe<BubbleColorEvent>()

--- a/app/src/main/java/com/fenchtose/movieratings/features/stickyview/FloatingRating.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/features/stickyview/FloatingRating.kt
@@ -14,7 +14,7 @@ class FloatingRating(private val context: Context) {
     set(value) {
         field = value
         value?.let {
-            setRating(it.rating.toString())
+            setRating(it.displayRating())
         }
     }
 

--- a/app/src/main/java/com/fenchtose/movieratings/model/api/MovieRatingApi.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/api/MovieRatingApi.kt
@@ -11,7 +11,8 @@ interface MovieRatingApi {
     fun getMovieRating(@Query("title") title: String,
                        @Query("year") year: String? = null,
                        @Query("type") type: String? = null,
-                       @Query("order") order: String = "popular"): Observable<MovieRating>
+                       @Query("order") order: String = "popular",
+                       @Query("check_anime") checkAnime: Int = 0): Observable<MovieRating>
 
     @GET("/trending")
     fun getTrending(@Query("period") period: String): Observable<Trending>

--- a/app/src/main/java/com/fenchtose/movieratings/model/api/provider/MovieRatingsProvider.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/api/provider/MovieRatingsProvider.kt
@@ -14,4 +14,9 @@ interface MovieRatingsProvider {
 const val ORDER_POPULAR = "popular"
 const val ORDER_RECENT = "recent"
 
-data class RatingRequest(val title: String, val year: String?, val order: String="popular", val appName: String)
+data class RatingRequest(
+        val title: String,
+        val year: String?,
+        val order: String="popular",
+        val checkAnime: Int = 0,
+        val appName: String)

--- a/app/src/main/java/com/fenchtose/movieratings/model/api/provider/RetrofitMovieRatingsProvider.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/api/provider/RetrofitMovieRatingsProvider.kt
@@ -54,7 +54,7 @@ class RetrofitMovieRatingsProvider(flutterRetrofit: Retrofit?,
                     } else {
                         lastRequest = request
                         if (useFlutterApi && flutterApi != null) {
-                            flutterApi.getMovieRating(request.title, request.year, order = request.order)
+                            flutterApi.getMovieRating(request.title, request.year, order = request.order, checkAnime = request.checkAnime)
                         } else if (omdbApi != null) {
 
                             omdbApi.getMovieInfo(BuildConfig.OMDB_API_KEY, request.title, request.year

--- a/app/src/main/java/com/fenchtose/movieratings/model/db/MovieDb.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/db/MovieDb.kt
@@ -15,7 +15,7 @@ import com.fenchtose.movieratings.model.db.entity.*
     (MovieCollectionEntry::class), (Episode::class),
     (DisplayedRating::class), (MovieRating::class),
     (RatingNotFound::class)],
-        version = 8)
+        version = 9)
 abstract class MovieDb : RoomDatabase() {
 
     abstract fun movieDao(): MovieDao
@@ -32,7 +32,7 @@ abstract class MovieDb : RoomDatabase() {
                             MIGRATION_1_to_2, MIGRATION_2_to_3,
                             MIGRATION_3_to_4, MIGRATION_4_to_5,
                             MIGRATION_5_to_6, MIGRATION_6_to_7,
-                            MIGRATION_7_to_8)
+                            MIGRATION_7_to_8, MIGRATION_8_to_9)
                     .build()
         }
 
@@ -90,6 +90,12 @@ abstract class MovieDb : RoomDatabase() {
             override fun migrate(_db: SupportSQLiteDatabase) {
                 _db.execSQL("CREATE TABLE IF NOT EXISTS `RATING_NOT_FOUND` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `TITLE` TEXT NOT NULL, `YEAR` TEXT NOT NULL, `TIMESTAMP` INTEGER NOT NULL)")
                 _db.execSQL("CREATE  INDEX `index_RATING_NOT_FOUND_TITLE` ON `RATING_NOT_FOUND` (`TITLE`)")
+            }
+        }
+
+        private val MIGRATION_8_to_9 = object: Migration(8, 9) {
+            override fun migrate(_db: SupportSQLiteDatabase) {
+                _db.execSQL("ALTER TABLE `MOVIE_RATINGS` ADD COLUMN `SOURCE` TEXT DEFAULT \"IMDB\" NOT NULL")
             }
         }
     }

--- a/app/src/main/java/com/fenchtose/movieratings/model/db/entity/MovieRating.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/db/entity/MovieRating.kt
@@ -4,20 +4,18 @@ import android.arch.persistence.room.ColumnInfo
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.Index
 import android.arch.persistence.room.PrimaryKey
-import com.fenchtose.movieratings.BuildConfig
-import com.fenchtose.movieratings.model.entity.OmdbMovie
-import com.fenchtose.movieratings.util.FixTitleUtils
+import com.fenchtose.movieratings.model.db.entity.MovieRating.Companion.ID
 
-@Entity(tableName = "MOVIE_RATINGS", indices = arrayOf(Index("IMDBID", unique = true)))
+@Entity(tableName = "MOVIE_RATINGS", indices = arrayOf(Index(ID, unique = true)))
 data class MovieRating(
         @PrimaryKey
-        @ColumnInfo(name = "IMDBID")
+        @ColumnInfo(name = ID)
         val imdbId: String,
 
-        @ColumnInfo(name = "IMDB_RATING")
+        @ColumnInfo(name = RATING)
         val rating: Float,
 
-        @ColumnInfo(name = "IMDB_VOTES")
+        @ColumnInfo(name = VOTES)
         val votes: Int,
 
         @ColumnInfo(name = "TITLE")
@@ -36,7 +34,10 @@ data class MovieRating(
         val endYear: Int = -1,
 
         @ColumnInfo(name = "TIMESTAMP")
-        val timestamp: Int = -1
+        val timestamp: Int = -1,
+
+        @ColumnInfo(name = "SOURCE")
+        val source: String
 ) {
 
     fun fitsYear(year: Int): Boolean {
@@ -64,31 +65,12 @@ data class MovieRating(
         return true
     }
 
-
-    /*fun toMovie(): Movie {
-        val movie = Movie()
-        movie.imdbId = imdbId
-        movie.title = title
-        movie.type = type
-
-        if (startYear != -1 && endYear != -1) {
-            movie.year = "$startYear - $endYear"
-        } else if (startYear != -1) {
-            movie.year = startYear.toString()
-        }
-
-        if (votes > 0) {
-            movie.imdbVotes = votes.toString()
-        }
-
-        if (rating > 0) {
-            movie.ratings = arrayListOf(Rating("Internet Movie Database", "$rating/10"))
-        }
-
-        movie.poster = "http://img.omdbapi.com/?i=$imdbId&h=600&apikey=${BuildConfig.OMDB_API_KEY}"
-
-        return movie
-    }*/
+    companion object {
+        // TODO change these column names
+        const val ID = "IMDBID"
+        const val RATING = "IMDB_RATING"
+        const val VOTES = "IMDB_VOTES"
+    }
 }
 
 @Entity(tableName = "RATING_NOT_FOUND", indices = arrayOf(Index("TITLE")))

--- a/app/src/main/java/com/fenchtose/movieratings/model/entity/MovieRating.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/entity/MovieRating.kt
@@ -21,6 +21,9 @@ data class MovieRating(
         @Json(name="type")
         val type: String,
 
+        @Json(name="source")
+        val source: String,
+
         @Json(name = "translated_title")
         val translatedTitle: String,
 
@@ -40,13 +43,22 @@ data class MovieRating(
                 translatedTitle = translatedTitle,
                 startYear = startYear,
                 endYear = endYear?: -1,
-                timestamp = timestamp
+                timestamp = timestamp,
+                source = source
         )
+    }
+
+    fun displayRating(): String {
+        if (source != "IMDB" && source.isNotBlank()) {
+            return "%.1f (%s)".format(rating, source)
+        }
+
+        return "%.1f".format(rating)
     }
 
     companion object {
         fun empty(): MovieRating {
-            return MovieRating("", -1f, -1, "", "", "", -1, -1)
+            return MovieRating("", -1f, -1, "", "", "", "",-1, -1)
         }
 
         fun fromMovie(movie: OmdbMovie): MovieRating {
@@ -73,7 +85,8 @@ data class MovieRating(
                         votes = movie.imdbVotes.replace(",","").toIntOrNull() ?: -1,
                         startYear = startYear,
                         endYear = endYear,
-                        translatedTitle = ""
+                        translatedTitle = "",
+                        source = "IMDB"
                 )
 
                 return rating
@@ -93,6 +106,7 @@ fun com.fenchtose.movieratings.model.db.entity.MovieRating.convert(): MovieRatin
             type = type,
             translatedTitle = translatedTitle,
             startYear = startYear,
-            endYear = endYear
+            endYear = endYear,
+            source = source
     )
 }

--- a/app/src/main/java/com/fenchtose/movieratings/model/preferences/UserPreferences.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/model/preferences/UserPreferences.kt
@@ -18,6 +18,7 @@ interface UserPreferences {
         val SHOW_ACTIVATE_FLUTTER = "show_activate_flutter"
         val USE_YEAR = "use_year"
         val SHOW_RECENT_RATING = "recent_rating"
+        val CHECK_ANIME = "check_anime"
         val ONBOARDING_SHOWN = "onboarding_shown"
         val LOCALE_INFO_SHOWN = "locale_info_shown"
 

--- a/app/src/main/java/com/fenchtose/movieratings/util/IntentUtils.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/util/IntentUtils.kt
@@ -11,6 +11,7 @@ import com.fenchtose.movieratings.BuildConfig
 import com.fenchtose.movieratings.MainActivity
 import com.fenchtose.movieratings.base.router.Router
 import com.fenchtose.movieratings.features.moviepage.MoviePath
+import com.fenchtose.movieratings.model.entity.MovieRating
 
 class IntentUtils {
 
@@ -116,23 +117,43 @@ class IntentUtils {
             return false
         }
 
-        fun openMovie(context: Context, imdb: String?, inApp: Boolean = false, newTask: Boolean = true): Boolean {
-            imdb?.let {
-                if (!inApp) {
-                    return openImdb(context, imdb, newTask)
-                }
-
-                val intent = Intent(context, MainActivity::class.java)
-                intent.putExtra(Router.HISTORY,
-                        Router.History()
-                                .addPath(MoviePath.KEY, MoviePath.createExtras(it))
-                                .toBundle())
+        fun openMAL(context: Context, id: String?, newTask: Boolean = true): Boolean {
+            id?.let {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://myanimelist.net/anime/$id"))
                 if (newTask) {
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 }
-
-                context.startActivity(intent)
+                context.startActivity(Intent.createChooser(intent, "Open My Anime List page with").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
                 return true
+            }
+
+            return false
+        }
+
+        fun openMovie(context: Context, movie: MovieRating?, inApp: Boolean = false, newTask: Boolean = true): Boolean {
+            movie?.let {
+                return when(it.source) {
+                    "IMDB" -> {
+                        if (!inApp) {
+                            return openImdb(context, it.imdbId, newTask)
+                        }
+
+                        val intent = Intent(context, MainActivity::class.java)
+                        intent.putExtra(Router.HISTORY,
+                                Router.History()
+                                        .addPath(MoviePath.KEY, MoviePath.createExtras(it.imdbId))
+                                        .toBundle())
+                        if (newTask) {
+                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        }
+
+                        context.startActivity(intent)
+                        true
+                    }
+                    "MAL" -> openMAL(context, it.imdbId, newTask)
+                    else -> false
+                }
+
             }
 
             return false

--- a/app/src/main/res/layout/settings_misc_section_page_layout.xml
+++ b/app/src/main/res/layout/settings_misc_section_page_layout.xml
@@ -94,6 +94,30 @@
 			android:background="@color/divider_color"/>
 
 		<TextView
+			android:textAppearance="@style/Text.Dark.Secondary"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:text="@string/settings_anime_info"
+			android:paddingStart="@dimen/gutter"
+			android:paddingEnd="@dimen/gutter"
+			android:layout_marginTop="@dimen/gutter"/>
+
+		<android.support.v7.widget.SwitchCompat
+			android:id="@+id/anime_toggle"
+			android:padding="@dimen/gutter"
+			android:text="@string/settings_anime"
+			android:visibility="gone"
+			tools:visibility="visible"
+			android:textAppearance="@style/Text.Dark"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"/>
+
+		<View
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:background="@color/divider_color"/>
+
+		<TextView
 			android:textAppearance="@style/Text.Dark.Secondary.Medium.Large"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
 	<string name="settings_api_fallback">Use Flutter\'s private APIs</string>
 	<string name="settings_api_order_info">In case there are multiple movies with the same title (and release year is not available), flutter shows you the ratings of the popular title (by votes). A lot of shows on Netflix are new so you can choose to see the ratings based on recency.</string>
 	<string name="settings_api_order_recent">Show recent titles</string>
+	<string name="settings_anime_info">Flutter can use My Anime List (MAL) database to get ratings of Animes if it\'s not found on IMDb.</string>
+	<string name="settings_anime">Use MAL database</string>
 	<string name="settings_install_tts_unsupported">It seems that Text to Speech is not supported by the device.</string>
 	<string name="settings_export_data_dialog_title">Export your data</string>
 	<string name="settings_export_data_dialog_content">Flutter lets you export your data in json format. You may share it with your friends, send yourself a copy for back-up or just keep it on your device.</string>


### PR DESCRIPTION
**Title**: Support added to show ratings from My Anime List (and potentially other sources)

**Description**
As per the feature request #70, I'm adding support for ratings from My Anime List. I need to do some structural changes in order to support multiple sources and not just IMDB. The `RatingDisplayer` will open MAL page in the browser instead of opening the page in the app.

**What did you change?**
 - Updated DB schema to 9 and added a migration.
 - Added `SOURCE` column to `MOVIE_RATINGS` table (default value being "IMDB") so that we know if the source is IMDB or MAL or something else.
 - Open MAL website if the user clicks on the bubble.
 - Added an option in Misc section to disable MAL.

**Screenshots**
<img src="https://user-images.githubusercontent.com/1256649/46903823-204ee080-cedb-11e8-8d55-683200a0d7fc.png" alt="drawing" width="320"/>
