### PR TITLE
Debug menu

### DIFF
--- a/app/src/debug/java/com/fenchtose/movieratings/features/debugging/DebugOptionsFragment.kt
+++ b/app/src/debug/java/com/fenchtose/movieratings/features/debugging/DebugOptionsFragment.kt
@@ -1,0 +1,60 @@
+package com.fenchtose.movieratings.features.debugging
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.fenchtose.movieratings.R
+import com.fenchtose.movieratings.analytics.ga.GaCategory
+import com.fenchtose.movieratings.analytics.ga.GaScreens
+import com.fenchtose.movieratings.base.BaseFragment
+import com.fenchtose.movieratings.base.RouterPath
+import com.fenchtose.movieratings.util.Constants
+import com.fenchtose.movieratings.util.isNotificationChannelBlocked
+import com.fenchtose.movieratings.util.showReviewAppNotification
+import com.fenchtose.movieratings.util.showSupportAppNotification
+
+class DebugOptionsFragment: BaseFragment() {
+    override fun canGoBack() = true
+    override fun getScreenTitle() = R.string.debug_screen_title
+    override fun screenName() =  GaScreens.DEBUGGING
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.debug_options_screen, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<View>(R.id.debug_notification_support).setOnClickListener {
+            sendSupportAppNotification()
+        }
+
+        view.findViewById<View>(R.id.debug_notification_rate).setOnClickListener {
+            sendRateAppNotification()
+        }
+    }
+
+    private fun sendSupportAppNotification() {
+        if (!isNotificationChannelBlocked(requireContext(), Constants.SUPPORT_CHANNEL_ID)) {
+            showSupportAppNotification(requireContext(), GaCategory.DEBUGGING)
+            return
+        }
+
+        showSnackbar("notification channel is blocked")
+    }
+
+    private fun sendRateAppNotification() {
+        if (!isNotificationChannelBlocked(requireContext(), Constants.SUPPORT_CHANNEL_ID)) {
+            showReviewAppNotification(requireContext(), GaCategory.DEBUGGING)
+            return
+        }
+
+        showSnackbar("notification channel is blocked")
+    }
+}
+
+class DebugOptionsPath: RouterPath<DebugOptionsFragment>() {
+    override fun createFragmentInstance(): DebugOptionsFragment {
+        return DebugOptionsFragment()
+    }
+}

--- a/app/src/debug/res/layout/debug_options_screen.xml
+++ b/app/src/debug/res/layout/debug_options_screen.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical">
+
+		<TextView
+			android:textAppearance="@style/Text.Dark.Secondary.Medium.Large"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:text="Notifications"
+			android:paddingStart="@dimen/gutter"
+			android:paddingEnd="@dimen/gutter"
+			android:layout_marginTop="@dimen/gutter"/>
+
+		<TextView
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:textAppearance="@style/Text.Dark.Secondary"
+			android:text="Send a test notification"
+			android:paddingStart="@dimen/gutter"
+			android:paddingEnd="@dimen/gutter"
+			android:layout_marginTop="@dimen/gutter"/>
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="horizontal">
+
+			<Button
+				android:id="@+id/debug_notification_support"
+				style="@style/Widget.AppCompat.Button.Colored"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:layout_margin="16dp"
+				android:text="Support app"/>
+
+			<Button
+				android:id="@+id/debug_notification_rate"
+				style="@style/Widget.AppCompat.Button.Colored"
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:layout_margin="16dp"
+				android:text="Rate app"/>
+
+		</LinearLayout>
+
+		<View
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:background="@color/divider_color"/>
+
+	</LinearLayout>
+
+</ScrollView>

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="app_name_short">Flutter Dev</string>
     <string name="accessibility_label">Flutter Movie Ratings Dev</string>
     <string name="import_activity_label">Import data to Dev Flutter</string>
+
+    <string name="debug_screen_title">Debug options</string>
 </resources>

--- a/app/src/main/java/com/fenchtose/movieratings/NetflixReaderService.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/NetflixReaderService.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import com.fenchtose.movieratings.analytics.ga.GaCategory
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import com.fenchtose.movieratings.analytics.ga.GaEvents
@@ -355,8 +356,7 @@ class NetflixReaderService : AccessibilityService() {
 
     private fun showSupportAppPrompt() {
         if (!isNotificationChannelBlocked(this, Constants.SUPPORT_CHANNEL_ID)) {
-            showSupportAppNotification(this)
-            GaEvents.SEND_NOTIFICATION.withLabel(GaLabels.NOTIFICATION_SUPPORT_APP).track()
+            showSupportAppNotification(this, GaCategory.SERVICE)
             historyKeeper?.inAppPurchasePromptShown()
             return
         }
@@ -366,8 +366,7 @@ class NetflixReaderService : AccessibilityService() {
 
     private fun showRateAppPrompt() {
         if (!isNotificationChannelBlocked(this, Constants.SUPPORT_CHANNEL_ID)) {
-            showReviewAppNotification(this)
-            GaEvents.SEND_NOTIFICATION.withLabel(GaLabels.NOTIFICATION_RATE_APP).track()
+            showReviewAppNotification(this, GaCategory.SERVICE)
             historyKeeper?.rateAppPromptShown()
             return
         }

--- a/app/src/main/java/com/fenchtose/movieratings/analytics/ga/GaEvents.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/analytics/ga/GaEvents.kt
@@ -61,7 +61,7 @@ class GaEvents {
         val GET_RATINGS_ONLINE = GaEvent(GaCategory.SERVICE, "get rating online", "server: %s", true)
         val RATING_NOT_FOUND = GaEvent(GaCategory.SERVICE, "rating not found", "server: %s", true)
         val SHOW_RATINGS = GaEvent(GaCategory.SERVICE, "show rating", "%s", true)
-        val SEND_NOTIFICATION = GaEvent(GaCategory.SERVICE, "send notification", "%s", true)
+        val SEND_NOTIFICATION = GaEvent("%s", "send notification", "%s", true)
         val NOTIFICATION_BLOCKED = GaEvent(GaCategory.SERVICE, "notification blocked", "%s", true)
         val OPEN_NOTIFICATION = GaEvent(GaCategory.SERVICE, "open notification", "%s")
         val DISMISS_RATING = GaEvent(GaCategory.SERVICE, "dismiss", "rating")
@@ -91,6 +91,7 @@ class GaCategory {
         const val SUPPORT_APP = "support app"
         const val TRENDING = "trending"
         const val BOTTOM_NAVIGATION = "bottom navigation"
+        const val DEBUGGING = "debugging"
     }
 }
 
@@ -115,6 +116,7 @@ class GaScreens {
         const val SETTINGS_TTS_SECTION = "settings tts section"
         const val SUPPORT_APP = "support app"
         const val TRENDING = "trending"
+        const val DEBUGGING = "debugging"
     }
 }
 

--- a/app/src/main/java/com/fenchtose/movieratings/features/info/AppInfoFragment.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/features/info/AppInfoFragment.kt
@@ -70,6 +70,7 @@ class AppInfoFragment: BaseFragment() {
             findViewById<View?>(R.id.premium_view)?.show(false)
             findViewById<View?>(R.id.feedback_view)?.show(true)
             findViewById<View?>(R.id.privacy_policy_view)?.show(true)
+            findViewById<View?>(R.id.debug_view)?.show(BuildConfig.DEBUG)
         }
     }
 

--- a/app/src/main/java/com/fenchtose/movieratings/features/info/InfoPageBottomView.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/features/info/InfoPageBottomView.kt
@@ -13,6 +13,7 @@ import com.fenchtose.movieratings.R
 import com.fenchtose.movieratings.analytics.ga.GaEvents
 import com.fenchtose.movieratings.base.router.Router
 import com.fenchtose.movieratings.features.accessinfo.AccessInfoFragment
+import com.fenchtose.movieratings.features.debugging.DebugOptionsPath
 import com.fenchtose.movieratings.features.premium.DonatePageFragment
 import com.fenchtose.movieratings.features.settings.SettingsFragment
 import com.fenchtose.movieratings.model.inAppAnalytics.DbHistoryKeeper
@@ -81,6 +82,10 @@ class InfoPageBottomView: LinearLayout {
         findViewById<View?>(R.id.privacy_policy_view)?.setOnClickListener {
             GaEvents.OPEN_PRIVACY_POLICY.withCategory(category).track()
             IntentUtils.openPrivacyPolicy(context)
+        }
+
+        findViewById<View?>(R.id.debug_view)?.setOnClickListener {
+            router?.go(DebugOptionsPath())
         }
     }
 

--- a/app/src/main/java/com/fenchtose/movieratings/util/NotificationUtils.kt
+++ b/app/src/main/java/com/fenchtose/movieratings/util/NotificationUtils.kt
@@ -20,7 +20,7 @@ import com.fenchtose.movieratings.base.router.Router
 import com.fenchtose.movieratings.features.premium.DonatePageFragment
 
 
-fun showSupportAppNotification(context: Context) {
+fun showSupportAppNotification(context: Context, category: String) {
     val intent = Intent(context, MainActivity::class.java)
     intent.putExtra("ga_event", GaEvents.OPEN_NOTIFICATION.withLabel(GaLabels.NOTIFICATION_SUPPORT_APP).toBundle())
     intent.putExtra(Router.HISTORY,
@@ -36,9 +36,11 @@ fun showSupportAppNotification(context: Context) {
             Constants.SUPPORT_APP_NOTIFICATION_ID,
             pendingIntent
     )
+
+    GaEvents.SEND_NOTIFICATION.withCategory(category).withLabel(GaLabels.NOTIFICATION_SUPPORT_APP).track()
 }
 
-fun showReviewAppNotification(context: Context) {
+fun showReviewAppNotification(context: Context, category: String) {
     val intent = Intent(context, MainActivity::class.java)
     intent.putExtra("ga_event", GaEvents.OPEN_NOTIFICATION.withLabel(GaLabels.NOTIFICATION_RATE_APP).toBundle())
     intent.putExtra(Router.HISTORY, Router.History().addPath("RateApp", Bundle()).toBundle())
@@ -50,6 +52,8 @@ fun showReviewAppNotification(context: Context) {
             Constants.REVIEW_APP_NOTIFICATION_ID,
             pendingIntent
     )
+
+    GaEvents.SEND_NOTIFICATION.withCategory(category).withLabel(GaLabels.NOTIFICATION_RATE_APP).track()
 }
 
 private fun showNotification(context: Context, @StringRes title: Int, @StringRes content: Int,

--- a/app/src/main/res/layout/info_page_bottom_container_layout.xml
+++ b/app/src/main/res/layout/info_page_bottom_container_layout.xml
@@ -257,6 +257,36 @@
 	</LinearLayout>
 
 	<LinearLayout
+		android:id="@+id/debug_view"
+		android:orientation="vertical"
+		android:layout_width="match_parent"
+		android:layout_height="48dp"
+		android:layout_gravity="bottom"
+		android:visibility="gone"
+		tools:visibility="visible"
+		android:background="@drawable/ripple_onyx_bg">
+
+		<View
+			android:visibility="gone"
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:background="#22ffffff"/>
+
+		<TextView
+			android:layout_width="match_parent"
+			android:layout_height="46dp"
+			android:text="@string/info_page_debug_cta"
+			android:padding="8dp"
+			android:layout_marginStart="8dp"
+			android:layout_marginEnd="8dp"
+			android:drawablePadding="16dp"
+			android:gravity="center_vertical"
+			android:textAppearance="@style/Text.Light.Medium.Big"
+			android:drawableStart="@drawable/ic_build_yellow_24dp"/>
+
+	</LinearLayout>
+
+	<LinearLayout
 		android:id="@+id/activate_button"
 		android:layout_width="match_parent"
 		android:layout_height="48dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
 	<string name="info_page_go_premium_cta">Support Flutter</string>
 	<string name="info_page_feedback_cta">Report a bug / feature</string>
 	<string name="info_page_privacy_policy_cta">Privacy policy</string>
+	<string name="info_page_debug_cta">Debug options</string>
 
     <string name="credit_dialog_title">Credits</string>
     <string name="credit_dialog_content">Flutter uses Open Movie Database to get movie ratings.</string>

--- a/app/src/release/java/com/fenchtose/features/debugging/DebugOptionsFragment.kt
+++ b/app/src/release/java/com/fenchtose/features/debugging/DebugOptionsFragment.kt
@@ -1,0 +1,16 @@
+package com.fenchtose.movieratings.features.debugging
+
+import com.fenchtose.movieratings.base.BaseFragment
+import com.fenchtose.movieratings.base.RouterPath
+
+class DebugOptionsFragment: BaseFragment() {
+    override fun canGoBack() = true
+    override fun getScreenTitle() = 0
+    override fun screenName() =  GaScreens.DEBUGGING
+}
+
+class DebugOptionsPath: RouterPath<DebugOptionsFragment>() {
+    override fun createFragmentInstance(): DebugOptionsFragment {
+        return DebugOptionsFragment()
+    }
+}

--- a/app/src/release/java/com/fenchtose/movieratings/features/debugging/DebugOptionsFragment.kt
+++ b/app/src/release/java/com/fenchtose/movieratings/features/debugging/DebugOptionsFragment.kt
@@ -2,6 +2,7 @@ package com.fenchtose.movieratings.features.debugging
 
 import com.fenchtose.movieratings.base.BaseFragment
 import com.fenchtose.movieratings.base.RouterPath
+import com.fenchtose.movieratings.analytics.ga.GaScreens
 
 class DebugOptionsFragment: BaseFragment() {
     override fun canGoBack() = true


### PR DESCRIPTION
**Title**: Debugging options added to the app.

**Description**
It's convenient to have some feature options handy for debugging. eg. Testing notifications, etc. This PR adds `DebugOptionsFragment` and `DebugOptionsPath` in debug. It contains only notification feature as of now. In release, these classes are stubbed.

**Screenshots**
![device-2018-12-30-130114](https://user-images.githubusercontent.com/1256649/50547096-5b87c280-0c33-11e9-98c9-546ad8c9f073.png)
